### PR TITLE
Edit basscss to basscss-rails in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Repackaged from <https://github.com/jxnblk/basscss> by Brent Jackson.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'basscss'
+gem 'basscss-rails'
 ```
 
 And then execute:
@@ -18,7 +18,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install basscss
+    $ gem install basscss-rails
 
 ##### Using Sass
 


### PR DESCRIPTION
Gem on RubyGems is called basscss-rails and not basscss, this edit allows you to add the gem and have it find it to pull down form rubygems.
