### PR TITLE
Fixed 'using css' section, no semi-colon required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You will then need to require the stylesheet in your application.scss:
 Or, in your application.css:
 
 ```css
-*= require basscss/basscss;
+*= require basscss/basscss
 ```
 
 ## Usage


### PR DESCRIPTION
Semi-column causes pipeline to barf.